### PR TITLE
bolt socks!

### DIFF
--- a/sock-shop/k8s/front-end-dep.yaml
+++ b/sock-shop/k8s/front-end-dep.yaml
@@ -13,7 +13,7 @@ spec:
     spec:
       containers:
       - name: front-end
-        image: weaveworksdemos/front-end:0.3.12
+        image: ryanycoleman/front-end:87adf24
         resources:
           limits:
             cpu: 300m


### PR DESCRIPTION
This commit switches the front-end image to a build I've made to replace two of the scrolling hero images with Bolt and DAG socks. Some of the messaging is tweaked as well and a Bolt socks logo replaces the Weaveworks logo.